### PR TITLE
Add full es2017 support

### DIFF
--- a/generators/mocha/templates/sequelize.ts
+++ b/generators/mocha/templates/sequelize.ts
@@ -1,7 +1,6 @@
 import { sequelize } from '../initialization/sequelize';
 
-const models = Object.keys(sequelize.models)
-  .map(key => sequelize.models[key]);
+const models = Object.values(sequelize.models);
 
 beforeEach(async () => Promise.all(models.map(model =>
   model.truncate({ cascade: true })

--- a/generators/typescript/templates/tsconfig.json
+++ b/generators/typescript/templates/tsconfig.json
@@ -6,7 +6,8 @@
     "experimentalDecorators": true,
     "lib": [
       "es7",
-      "dom"
+      "dom",
+      "es2017.object"
     ],
     "module": "commonjs",
     "moduleResolution": "node",

--- a/generators/typescript/templates/tsconfig.json
+++ b/generators/typescript/templates/tsconfig.json
@@ -5,9 +5,8 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": [
-      "es7",
       "dom",
-      "es2017.object"
+      "es2017"
     ],
     "module": "commonjs",
     "moduleResolution": "node",
@@ -16,7 +15,7 @@
     "sourceMap": true,
     "suppressImplicitAnyIndexErrors": true,
     "strictNullChecks": true,
-    "target": "es6"
+    "target": "es2017"
   },
   "include": [
     "./src/**/*.ts",


### PR DESCRIPTION
Node 8.11.4 has full support for the static Object methods from ES2017. By enabling this feature we can use the [Object.values](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object/values) method in TypeScript.

BTW, what do you think about directly set the target to `es2017` (https://github.com/comparaonline/generator-ts-microservice/issues/48)?

**Update** -> Set the target to `es2017`

References
https://node.green/#ES2017-features-Object-static-methods