### PR TITLE
Fix tsnode tests

### DIFF
--- a/generators/mocha/index.js
+++ b/generators/mocha/index.js
@@ -13,7 +13,8 @@ module.exports = class extends Generator {
 
     const pkg = extend({
       scripts: {
-        test: 'NODE_CONFIG_ENV=test mocha',
+        test: 'TS_NODE_FILES=true NODE_CONFIG_ENV=test mocha',
+        'test:fast': 'TS_NODE_FILES=true NODE_CONFIG_ENV=test mocha',
         pretest: this._preTest()
       }
     }, currentPkg);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-ts-microservice",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "This bootstrap a microservice to run on the ComparaOnline infrastructure",
   "homepage": "https://github.com/comparaonline/generator-ts-microservice",
   "author": {


### PR DESCRIPTION
tsnode needs the `files` flag to behave like `tsc`.
add the `test:fast` script to skip running pretest scripts