### PR TITLE
Fix development initialization

### DIFF
--- a/generators/event-streamer/templates/event-server/index.ts
+++ b/generators/event-streamer/templates/event-server/index.ts
@@ -7,7 +7,7 @@ import { application } from '../application';
 export const kafkaServer = new KafkaServer(
   router,
   config.get('kafka'),
-  config.get('kafka.rdConfig')
+  config.has('kafka.rdConfig') ? config.get('kafka.rdConfig') : {}
 );
 
 application.onStart(() => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-ts-microservice",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "This bootstrap a microservice to run on the ComparaOnline infrastructure",
   "homepage": "https://github.com/comparaonline/generator-ts-microservice",
   "author": {


### PR DESCRIPTION
There was an error initializing the development environment as no rdConfig was defined by default. It will  now default to `{}`