### PR TITLE
Fix graphql generation

### DIFF
--- a/generators/graphql-server/templates/graphql-server/index.ts
+++ b/generators/graphql-server/templates/graphql-server/index.ts
@@ -7,7 +7,7 @@ import resolvers from './resolvers';
 
 const path = `${config.get('server.baseUrl')}/graphql`;
 
-const typeDefs = gql(schema.join());
+const typeDefs = gql(schema.join(''));
 const serverOptions = {
   typeDefs,
   resolvers,

--- a/generators/graphql-server/templates/graphql-server/schema/index.ts
+++ b/generators/graphql-server/templates/graphql-server/schema/index.ts
@@ -3,4 +3,4 @@ import types from './types';
 import queries from './queries';
 import mutations from './mutations';
 
-export default [...types, ...queries, ...mutations];
+export default [types, queries, mutations];

--- a/generators/graphql-server/templates/graphql-server/schema/mutations/index.ts
+++ b/generators/graphql-server/templates/graphql-server/schema/mutations/index.ts
@@ -1,9 +1,10 @@
 /* istanbul ignore file */
+import test from './test';
 
 const queries:string[] = [];
 
 const allQueries: string = queries.concat(
-
+  test
 ).join();
 
 export default `

--- a/generators/graphql-server/templates/graphql-server/schema/mutations/test.ts
+++ b/generators/graphql-server/templates/graphql-server/schema/mutations/test.ts
@@ -1,0 +1,4 @@
+/* istanbul ignore file */
+export default `
+  test(message: String!): String
+`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-ts-microservice",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "This bootstrap a microservice to run on the ComparaOnline infrastructure",
   "homepage": "https://github.com/comparaonline/generator-ts-microservice",
   "author": {


### PR DESCRIPTION
There were two issues that this PR aims to solve:
- `types`, `queries` and `mutations` are strings, so applying spread operator make them string arrays with each letter as character.
-- Removed spread operator
- Generating and empty `type Mutation {}` provoked n error in initialization. 
-- Added test mutation