### PR TITLE
Test server helper with jest

### DIFF
--- a/generators/datadog/index.js
+++ b/generators/datadog/index.js
@@ -99,7 +99,8 @@ module.exports = class extends Generator {
           host: 'datadog'
         },
         winston: {
-          format: 'simple'
+          format: 'simple',
+          level: 'info'
         }
       }
     );

--- a/generators/event-streamer/index.js
+++ b/generators/event-streamer/index.js
@@ -12,7 +12,7 @@ module.exports = class extends Generator {
   }
 
   static get dependencies() {
-    return ['@comparaonline/event-streamer@^3.1.0'];
+    return ['@comparaonline/event-streamer@^3.4.0'];
   }
 
   constructor(args, options) {
@@ -59,6 +59,13 @@ module.exports = class extends Generator {
     } catch (e) {
       this.log.error(`Error!!! ${e.message}`);
     }
+    if (this._useJest()) {
+      mkdirp.sync(this.destinationPath('src/event-server/__mocks__'));
+      this.fs.copy(
+        this.templatePath(`event-server/__mocks__/index.ts`),
+        this.destinationPath('src/event-server/__mocks__/index.ts')
+      );
+    }
     this._removeOldVersions();
   }
 
@@ -82,6 +89,10 @@ module.exports = class extends Generator {
   _testFramework() {
     return ['mocha', 'jest'].find(fw => this.options.hasDependency(fw))
       || fail('No test framework defined');
+  }
+
+  _useJest() {
+    return this.options.hasDependency('jest');
   }
 
   _removeOldVersions() {

--- a/generators/event-streamer/templates/__mocks__/index.ts
+++ b/generators/event-streamer/templates/__mocks__/index.ts
@@ -1,0 +1,4 @@
+/* istanbul ignore file */
+import { testServer } from '../../test-helpers/test-server';
+
+export const kafkaServer = testServer;

--- a/generators/event-streamer/templates/event-server/actions/__tests__/ping-action.jest.ts
+++ b/generators/event-streamer/templates/event-server/actions/__tests__/ping-action.jest.ts
@@ -1,12 +1,11 @@
-import { TestServer } from '@comparaonline/event-streamer';
-import { router } from '../../router';
+import { testServer } from '../../../test-helpers/test-server';
 import { Pong } from '../../events/ping-events';
+jest.mock('../../../event-server');
 
 describe('PingAction', () => {
   it('returns consumer data when pinged', async () => {
-    const server = new TestServer(router);
-    await server.input({ code: 'Ping' });
-    const published = server.emitted();
+    await testServer.input({ code: 'Ping' });
+    const published = testServer.emitted();
     expect(published).toHaveLength(1);
     expect(published[0]).toBeInstanceOf(Pong);
     const publishedData = JSON.parse(published[0].toString());

--- a/generators/jest/index.js
+++ b/generators/jest/index.js
@@ -46,11 +46,14 @@ module.exports = class extends Generator {
   }
 
   _testInitialization() {
-    const orms = this._orms();
-    if (orms.length === 0) return;
+    const helpers = this._orms();
+    if (this.options.hasDependency('event-streamer')) {
+      helpers.push('test-server');
+    }
+    if (helpers.length === 0) return;
     mkdirp.sync(this.destinationPath('src/test-helpers'));
-    orms
-      .map(orm => [`${orm}.ts`, `src/test-helpers/${orm}.ts`])
+    helpers
+      .map(helper => [`${helper}.ts`, `src/test-helpers/${helper}.ts`])
       .forEach(([from, to]) => this.fs.copy(
         this.templatePath(from),
         this.destinationPath(to)

--- a/generators/jest/templates/jest.config.js.ejs
+++ b/generators/jest/templates/jest.config.js.ejs
@@ -4,7 +4,6 @@ module.exports = {
   },
   roots: ['src/'],
   testEnvironment: 'node',
-  runInBand: true,
   testRegex: 'src(/.*)?/__tests__/[^/]*\\.test\\.(ts|js)$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   collectCoverage: true,

--- a/generators/jest/templates/test-server.ts
+++ b/generators/jest/templates/test-server.ts
@@ -1,0 +1,8 @@
+import { TestServer } from '@comparaonline/event-streamer';
+import { router } from '../event-server/router';
+
+export const testServer = new TestServer(router);
+
+beforeEach(() => {
+  testServer.cleanEmitted();
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-ts-microservice",
-  "version": "8.5.1",
+  "version": "8.6.0",
   "description": "This bootstrap a microservice to run on the ComparaOnline infrastructure",
   "homepage": "https://github.com/comparaonline/generator-ts-microservice",
   "author": {


### PR DESCRIPTION
## Summary
Add test server helper for jest. It creates a single instance of TestServer and clean the emitted events before each test. Also adds a mock to be able to mock default `kafkaServer` and avoid the creation of extra helpers for testing only.