### PR TITLE
fix: enable remote access to the node inspector

### DIFF
--- a/generators/docker/templates/docker-compose.yml
+++ b/generators/docker/templates/docker-compose.yml
@@ -24,7 +24,8 @@ services:
       - default
     ports:
       - "4000:4000"
-    command: "yarn watch:cmd node --inspect=9000 -r ts-node/register src/index.ts"
+      - "9000:9000"
+    command: "yarn watch:cmd node --inspect=0.0.0.0:9000 -r ts-node/register src/index.ts"
     volumes:
       - ".:/code"
       - "/code/node_modules"

--- a/generators/typescript/index.js
+++ b/generators/typescript/index.js
@@ -27,6 +27,6 @@ module.exports = class extends Generator {
     addScript(this, 'compile', 'tsc');
     addScript(this, 'clean', 'rm -rf build/*');
     addScript(this, 'start', 'node build');
-    addScript(this, 'start:dev', 'TS_NODE_FILES=true node --inspect=9000 -r ts-node/register src/index.ts');
+    addScript(this, 'start:dev', 'TS_NODE_FILES=true node --inspect=0.0.0.0:9000 -r ts-node/register src/index.ts');
   }
 };


### PR DESCRIPTION
In the current config we can't access to the node.js inspector